### PR TITLE
Make CCP positioning ignore collision

### DIFF
--- a/addons - Copy/RD501_Main/functions/medical_ccp/fnc_deployCCPServer.sqf
+++ b/addons - Copy/RD501_Main/functions/medical_ccp/fnc_deployCCPServer.sqf
@@ -18,7 +18,7 @@ params["_target"];
 
 _position = position _target;
 deleteVehicle _target;
-_spawner = rd501_medical_ccp_building createVehicle _position;
+_spawner = createVehicle[rd501_medical_ccp_building, _position, [], 0, "CAN_COLLIDE"];
 systemChat format["Deployed CCP"];
 
 _jipId = ["rd501_medical_ccp_deployCCPLocal", [_spawner]] call CBA_fnc_globalEventJIP; // raise on all clients (we should be on server)


### PR DESCRIPTION
Should be placable at exactly the position of the vehicle or supply drop now.