### PR TITLE
Add Vehicle EMP

### DIFF
--- a/addons - Copy/RD501_Main/XEH_postinit.sqf
+++ b/addons - Copy/RD501_Main/XEH_postinit.sqf
@@ -154,3 +154,20 @@ if(hasInterface) then {
 ["rd501_shield_normalHealth", {
 	_this call rd501_fnc_shield_onNormalHealth;
 }] call CBA_fnc_addEventHandler;
+
+// Vehicle EMP
+["Car", "HitPart", {
+	_this call rd501_fnc_emp_hitHandler;
+}] call CBA_fnc_addClassEventHandler;
+
+["Tank", "HitPart", {
+	_this call rd501_fnc_emp_hitHandler;
+}] call CBA_fnc_addClassEventHandler;
+
+["Ship", "HitPart", {
+	_this call rd501_fnc_emp_hitHandler;
+}] call CBA_fnc_addClassEventHandler;
+
+["Air", "HitPart", {
+	_this call rd501_fnc_emp_hitHandler;
+}] call CBA_fnc_addClassEventHandler;

--- a/addons - Copy/RD501_Main/XEH_postinit.sqf
+++ b/addons - Copy/RD501_Main/XEH_postinit.sqf
@@ -156,18 +156,6 @@ if(hasInterface) then {
 }] call CBA_fnc_addEventHandler;
 
 // Vehicle EMP
-["Car", "HitPart", {
-	_this call rd501_fnc_emp_hitHandler;
-}] call CBA_fnc_addClassEventHandler;
-
-["Tank", "HitPart", {
-	_this call rd501_fnc_emp_hitHandler;
-}] call CBA_fnc_addClassEventHandler;
-
-["Ship", "HitPart", {
-	_this call rd501_fnc_emp_hitHandler;
-}] call CBA_fnc_addClassEventHandler;
-
-["Air", "HitPart", {
+["All", "HitPart", {
 	_this call rd501_fnc_emp_hitHandler;
 }] call CBA_fnc_addClassEventHandler;

--- a/addons - Copy/RD501_Main/XEH_preInit.sqf
+++ b/addons - Copy/RD501_Main/XEH_preInit.sqf
@@ -176,4 +176,10 @@ macro_prep_xeh(shield\fnc_shield_onLowHealth.sqf,shield_onLowHealth)
 macro_prep_xeh(shield\fnc_shield_onNormalHealth.sqf,shield_onNormalHealth)
 macro_prep_xeh(shield\fnc_shield_regenPerFrameHandler.sqf,shield_regenPerFrameHandler)
 
+// Vehicle EMP
+macro_prep_xeh(emp_vehicle\fnc_emp_hitVehicle.sqf,emp_hitVehicle)
+macro_prep_xeh(emp_vehicle\fnc_emp_hitHandler.sqf,emp_hitHandler)
+macro_prep_xeh(emp_vehicle\fnc_emp_enableVehicle.sqf,emp_enableVehicle)
+macro_prep_xeh(emp_vehicle\fnc_emp_disableVehicle.sqf,emp_disableVehicle)
+
 diag_log "RD501 PREP Complete";

--- a/addons - Copy/RD501_Main/functions/emp_vehicle/README.md
+++ b/addons - Copy/RD501_Main/functions/emp_vehicle/README.md
@@ -1,0 +1,65 @@
+# Vehicle EMP
+
+## EMP Duration
+
+The calculated duration is given by:
+
+```sqf
+ _effectiveDuration = _empDuration * (1 + ((-_empResistancePercent)/100));
+```
+
+or
+
+```c
+Effective Duration = Ammo Duration * (1 + (-Resistance/100))
+```
+
+Therefore:
+
+- A resistance of < 0 will produce an INCREASE in duration.
+- A resistance of > 0 will produce a DECREASE in duration.
+- A resistance of 0 will produce the same duration defined on the ammo.
+- A resistance of 100 will produce a 0 duration (no effect).
+- A duration of 0 will always result in no effect.
+
+> An effective duration of 0 is assumed for calculated durations < 1 for performance.
+
+## Configuration Properties
+
+### EMP Enabled
+
+Specify if the given ammo has an emp effect on vehicles.
+
+Where to define: `CfgAmmo -> Ammo`.
+
+`rd501_emp_vehicle_enabled=1`
+
+Default: `0`
+
+### EMP Max Duration
+
+You can specify how long a given set of ammo can disable a vehicle for (at maximum). Resistance will reduce this.
+
+Where to define: `CfgAmmo -> Ammo`.
+
+`rd501_emp_vehicle_duration=number`
+
+> `number` is the number of seconds this ammo will disable a vehicle for.
+
+> Note that this is only factored in, if a vehicle has a resistance of 100%, then the emp will not do anything. 50% resistance will halve the duration etc.
+
+Default: `10`
+
+### EMP Resistance
+
+You can specify a vehicles resistance (as a %) to the effects of EMP.
+
+Where to define: `CfgVehicles -> Vehicle`.
+
+`rd501_emp_vehicle_resistance_percent=number`
+
+> `number` is the whole number percentage (max 100, min unbound) which will be applied as a reduction to the given ammo's EMP duration.
+
+> `rd501_emp_vehicle_resistance_percent=100` is effectively disabling the effects on emp on the vehicle. (Immunity)
+
+Default: `0`

--- a/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_disableVehicle.sqf
+++ b/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_disableVehicle.sqf
@@ -1,6 +1,7 @@
 params["_vehicle"];
 
 if!(local _vehicle) exitWith { };
+diag_log format["[RD501][Vehicle EMP] Disabling Vehicle '%1'", _vehicle];
 
 _vehicle allowCrewInImmobile true;
 _vehicle lock 2;
@@ -14,7 +15,7 @@ _vehicle lock 2;
 	_x disableAI "FSM";
 } forEach crew _vehicle;
 
-(getAllHitPointsDamage _vehicle) params [["_allHitPoints", []], ["", []], ["", []]];
+(getAllHitPointsDamage _vehicle) params [["_allHitPoints", []]];
 
 {
 	private _isEngineLower = (_x find "engine") != -1;

--- a/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_disableVehicle.sqf
+++ b/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_disableVehicle.sqf
@@ -1,0 +1,34 @@
+params["_vehicle"];
+
+if!(local _vehicle) exitWith { };
+
+_vehicle allowCrewInImmobile true;
+_vehicle lock 2;
+
+{
+	_x setBehaviour "CARELESS";
+	_x setCombatMode "BLUE";
+	_x disableAI "TARGET";
+	_x disableAI "AUTOTARGET";
+	_x disableAI "MOVE";
+	_x disableAI "FSM";
+} forEach crew _vehicle;
+
+(getAllHitPointsDamage _vehicle) params [["_allHitPoints", []], ["", []], ["", []]];
+
+{
+	private _isEngineLower = (_x find "engine") != -1;
+	private _isEngineUpper = (_x find "Engine") != -1;
+	if(_isEngineLower || _isEngineUpper) then {
+		_vehicle setHitPointDamage [_x, 1, true];
+		diag_log format["[RD501][Vehicle EMP] Damaging %1", _x];
+	};
+
+	private _isTurretLower = (_x find "turret") != -1;
+	private _isTurretUpper = (_x find "Turret") != -1;
+	if(_isEngineLower || _isEngineUpper) then {
+		_vehicle setHitPointDamage [_x, 1, true];
+		diag_log format["[RD501][Vehicle EMP] Damaging %1", _x];
+	};
+} forEach _allHitPoints;
+

--- a/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_enableVehicle.sqf
+++ b/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_enableVehicle.sqf
@@ -1,6 +1,7 @@
 params["_vehicle"];
 
 if!(local _vehicle) exitWith { };
+diag_log format["[RD501][Vehicle EMP] Enabling Vehicle '%1'", _vehicle];
 
 _vehicle allowCrewInImmobile false;
 _vehicle lock 0;
@@ -14,7 +15,7 @@ _vehicle lock 0;
 	_x enableAI "FSM";
 } forEach crew _vehicle;
 
-(getAllHitPointsDamage _vehicle) params [["_allHitPoints", []], ["_allHitPointsSelections", []], ["_allHitPointDamages", []]];
+(getAllHitPointsDamage _vehicle) params [["_allHitPoints", []]];
 
 {
 	private _isEngineLower = (_x find "engine") != -1;

--- a/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_enableVehicle.sqf
+++ b/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_enableVehicle.sqf
@@ -1,0 +1,35 @@
+params["_vehicle"];
+
+if!(local _vehicle) exitWith { };
+
+_vehicle allowCrewInImmobile false;
+_vehicle lock 0;
+
+{
+	_x setBehaviour "AWARE";
+	_x setCombatMode "YELLOW";
+	_x enableAI "TARGET";
+	_x enableAI "AUTOTARGET";
+	_x enableAI "MOVE";
+	_x enableAI "FSM";
+} forEach crew _vehicle;
+
+(getAllHitPointsDamage _vehicle) params [["_allHitPoints", []], ["_allHitPointsSelections", []], ["_allHitPointDamages", []]];
+
+{
+	private _isEngineLower = (_x find "engine") != -1;
+	private _isEngineUpper = (_x find "Engine") != -1;
+	if(_isEngineLower || _isEngineUpper) then {
+		_vehicle setHitPointDamage [_x, 0];
+		diag_log format["[RD501][Vehicle EMP] Repairing %1", _x];
+	};
+
+	private _isTurretLower = (_x find "turret") != -1;
+	private _isTurretUpper = (_x find "Turret") != -1;
+	if(_isEngineLower || _isEngineUpper) then {
+		_vehicle setHitPointDamage [_x, 0];
+		diag_log format["[RD501][Vehicle EMP] Repairing %1", _x];
+	};
+} forEach _allHitPoints;
+
+_vehicle engineOn true;

--- a/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_hitHandler.sqf
+++ b/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_hitHandler.sqf
@@ -1,5 +1,5 @@
 (_this select 0) params ["_target", "_shooter", "_projectile", "_position", "_velocity", "_selection", "_ammo", "_vector", "_radius", "_surfaceType", "_isDirect"];
 
 if(_target isEqualTo objNull) exitWith { systemChat "Target is null idk why, hi random citizen <3"; }; 
-
-[_ammo, _target] call rd501_fnc_emp_hitVehicle;
+private _ammoClass = _ammo select 4;
+[_ammoClass, _target] call rd501_fnc_emp_hitVehicle;

--- a/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_hitHandler.sqf
+++ b/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_hitHandler.sqf
@@ -1,0 +1,5 @@
+(_this select 0) params ["_target", "_shooter", "_projectile", "_position", "_velocity", "_selection", "_ammo", "_vector", "_radius", "_surfaceType", "_isDirect"];
+
+if(_target isEqualTo objNull) exitWith { systemChat "Target is null idk why, hi random citizen <3"; }; 
+
+[_ammo, _target] call rd501_fnc_emp_hitVehicle;

--- a/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_hitVehicle.sqf
+++ b/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_hitVehicle.sqf
@@ -19,7 +19,7 @@ if(isNumber (_config >> "rd501_emp_vehicle_resistance_percent")) then {
 	_empResistancePercent = _empResistancePercent max 100;
 };
 
-private _effectiveDuration = _empDuration * (1 + ((- _empResistancePercent)/100));
+private _effectiveDuration = _empDuration * (1 + ((-_empResistancePercent)/100));
 
 if(_effectiveDuration <= 1) exitWith { diag_log "[RD501][Vehicle EMP] Effective EMP Duration too low, not worth setting. Skipped." };
 

--- a/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_hitVehicle.sqf
+++ b/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_hitVehicle.sqf
@@ -1,0 +1,36 @@
+params["_ammo", "_vehicle"];
+
+private _config = configFile >> "CfgAmmo" >> _ammo;
+
+private _empEnabled = 10;
+if(isNumber (_config >> "rd501_emp_vehicle_duration")) then {
+	_empEnabled = getNumber (_config >> "rd501_emp_vehicle_duration");
+};
+
+private _empDuration = 10;
+if(isNumber (_config >> "rd501_emp_vehicle_duration")) then {
+	_empDuration = getNumber (_config >> "rd501_emp_vehicle_duration");
+};
+
+_config = configFile >> "CfgVehicles" >> (typeOf _vehicle);
+private _empResistancePercent = 0;
+if(isNumber (_config >> "rd501_emp_vehicle_resistance_percent")) then {
+	_empResistancePercent = getNumber (_config >> "rd501_emp_vehicle_resistance_percent");
+	_empResistancePercent = _empResistancePercent max 100;
+};
+
+private _effectiveDuration = _empDuration * (1 + ((- _empResistancePercent)/100));
+
+if(_effectiveDuration <= 1) exitWith { diag_log "[RD501][Vehicle EMP] Effective EMP Duration too low, not worth setting. Skipped." };
+
+[_vehicle] call rd501_fnc_emp_disableVehicle;
+[
+	{
+		params["_vehicle"];
+		if(alive _vehicle) then {
+			[_vehicle] call rd501_fnc_emp_enableVehicle;
+		};
+	},
+	[_vehicle],
+	_effectiveDuration
+] call CBA_fnc_waitAndExecute;

--- a/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_hitVehicle.sqf
+++ b/addons - Copy/RD501_Main/functions/emp_vehicle/fnc_emp_hitVehicle.sqf
@@ -2,10 +2,12 @@ params["_ammo", "_vehicle"];
 
 private _config = configFile >> "CfgAmmo" >> _ammo;
 
-private _empEnabled = 10;
-if(isNumber (_config >> "rd501_emp_vehicle_duration")) then {
-	_empEnabled = getNumber (_config >> "rd501_emp_vehicle_duration");
+private _empEnabled = 0;
+if(isNumber (_config >> "rd501_emp_vehicle_enabled")) then {
+	_empEnabled = getNumber (_config >> "rd501_emp_vehicle_enabled");
 };
+
+if(_empEnabled != 1) exitWith { };
 
 private _empDuration = 10;
 if(isNumber (_config >> "rd501_emp_vehicle_duration")) then {
@@ -20,9 +22,11 @@ if(isNumber (_config >> "rd501_emp_vehicle_resistance_percent")) then {
 };
 
 private _effectiveDuration = _empDuration * (1 + ((-_empResistancePercent)/100));
+diag_log format["[RD501][Vehicle EMP] Effective Duration = %1 seconds", _effectiveDuration];
 
 if(_effectiveDuration <= 1) exitWith { diag_log "[RD501][Vehicle EMP] Effective EMP Duration too low, not worth setting. Skipped." };
 
+diag_log format["[RD501][Vehicle EMP] Enabling %1", _vehicle];
 [_vehicle] call rd501_fnc_emp_disableVehicle;
 [
 	{

--- a/addons - Copy/RD501_Main/functions/fired_deployable/fnc_fired_deployable_firedHandler.sqf
+++ b/addons - Copy/RD501_Main/functions/fired_deployable/fnc_fired_deployable_firedHandler.sqf
@@ -45,3 +45,4 @@ if (_deployable == 1) then {
 		}
 	] call CBA_fnc_waitUntilAndExecute;
 };
+

--- a/addons - Copy/RD501_Weapons/_ammo/config.cpp
+++ b/addons - Copy/RD501_Weapons/_ammo/config.cpp
@@ -601,6 +601,8 @@ class CfgAmmo
 		submunitionDirectionType="";
 		CraterEffects="";
 		explosionEffects="JLTS_fx_exp_EMP";
+		rd501_emp_vehicle_enabled=1;
+		rd501_emp_vehicle_duration=15;
 	};
 	class macro_new_ammo(rps4burst):R_PG32V_F
 	{


### PR DESCRIPTION
# Vehicle EMP

## EMP Duration

The calculated duration is given by:

```sqf
 _effectiveDuration = _empDuration * (1 + ((-_empResistancePercent)/100));
```

or

```c
Effective Duration = Ammo Duration * (1 + (-Resistance/100))
```

Therefore:

- A resistance of < 0 will produce an INCREASE in duration.
- A resistance of > 0 will produce a DECREASE in duration.
- A resistance of 0 will produce the same duration defined on the ammo.
- A resistance of 100 will produce a 0 duration (no effect).
- A duration of 0 will always result in no effect.

> An effective duration of 0 is assumed for calculated durations < 1 for performance.

## Configuration Properties

### EMP Enabled

Specify if the given ammo has an emp effect on vehicles.

Where to define: `CfgAmmo -> Ammo`.

`rd501_emp_vehicle_enabled=1`

Default: `0`

### EMP Max Duration

You can specify how long a given set of ammo can disable a vehicle for (at maximum). Resistance will reduce this.

Where to define: `CfgAmmo -> Ammo`.

`rd501_emp_vehicle_duration=number`

> `number` is the number of seconds this ammo will disable a vehicle for.

> Note that this is only factored in, if a vehicle has a resistance of 100%, then the emp will not do anything. 50% resistance will halve the duration etc.

Default: `10`

### EMP Resistance

You can specify a vehicles resistance (as a %) to the effects of EMP.

Where to define: `CfgVehicles -> Vehicle`.

`rd501_emp_vehicle_resistance_percent=number`

> `number` is the whole number percentage (max 100, min unbound) which will be applied as a reduction to the given ammo's EMP duration.

> `rd501_emp_vehicle_resistance_percent=100` is effectively disabling the effects on emp on the vehicle. (Immunity)

Default: `0`
